### PR TITLE
Increasing the tap area

### DIFF
--- a/Onboarding/OnboardingStepView.swift
+++ b/Onboarding/OnboardingStepView.swift
@@ -28,7 +28,8 @@ struct OnboardingStepView: View {
                 .fontWeight(.medium)
                 .multilineTextAlignment(.center)
         }
-    .padding()
+        .padding()
+        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
Currently, it is only possible to drag the slides by tapping on the content (image or text). There is no reaction on taps on the "empty space". Adding contentShape(Rectangle()) will make the whole view draggable.